### PR TITLE
コンテストページの実装

### DIFF
--- a/scripts/fetchOpenapi.js
+++ b/scripts/fetchOpenapi.js
@@ -4,9 +4,8 @@ const fetch = require('node-fetch')
 const fs = require('fs').promises
 const path = require('path')
 
-// 一時的にContestが正しくなっているもののURLに変更
 const URL =
-  'https://raw.githubusercontent.com/traPtitech/traPortfolio/fix/replace_user_contests_response/docs/swagger/traPortfolio.v1.yaml'
+  'https://raw.githubusercontent.com/traPtitech/traPortfolio/main/docs/swagger/traPortfolio.v1.yaml'
 const dist = './traPortfolio.v1.yaml'
 
 if (process.env.SKIP_GENAPI) {

--- a/scripts/fetchOpenapi.js
+++ b/scripts/fetchOpenapi.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 // 一時的にContestが正しくなっているもののURLに変更
 const URL =
-  'https://raw.githubusercontent.com/traPtitech/traPortfolio/fix/swagger_contests/docs/swagger/traPortfolio.v1.yaml'
+  'https://raw.githubusercontent.com/traPtitech/traPortfolio/fix/replace_user_contests_response/docs/swagger/traPortfolio.v1.yaml'
 const dist = './traPortfolio.v1.yaml'
 
 if (process.env.SKIP_GENAPI) {

--- a/scripts/fetchOpenapi.js
+++ b/scripts/fetchOpenapi.js
@@ -4,8 +4,9 @@ const fetch = require('node-fetch')
 const fs = require('fs').promises
 const path = require('path')
 
+// 一時的にContestが正しくなっているもののURLに変更
 const URL =
-  'https://raw.githubusercontent.com/traPtitech/traPortfolio/master/docs/swagger/traPortfolio.v1.yaml'
+  'https://raw.githubusercontent.com/traPtitech/traPortfolio/fix/swagger_contests/docs/swagger/traPortfolio.v1.yaml'
 const dist = './traPortfolio.v1.yaml'
 
 if (process.env.SKIP_GENAPI) {

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -18,10 +18,6 @@ defineProps<Props>()
         <icon name="mdi:calendar" />
         {{ getFullDayString(new Date(contest.duration.since)) }}
       </p>
-      <p :class="$style.teams">
-        <icon name="mdi:account-group" />
-        {{ contest.teams.length }} チーム
-      </p>
     </div>
   </router-link>
 </template>
@@ -44,11 +40,5 @@ defineProps<Props>()
   align-items: center;
   gap: 0.5rem;
   margin-top: 0.75rem;
-}
-.teams {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
 }
 </style>

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -1,10 +1,10 @@
 <script lang="ts" setup>
-import type { UserContest } from '/@/lib/apis'
+import type { Contest } from '/@/lib/apis'
 import Icon from '/@/components/UI/Icon.vue'
 import { getFullDayString } from '/@/lib/date'
 
 interface Props {
-  contest: UserContest
+  contest: Contest
 }
 
 defineProps<Props>()
@@ -20,7 +20,7 @@ defineProps<Props>()
       </p>
       <p :class="$style.teams">
         <icon name="mdi:account-group" />
-        {{ contest.teamCount }} チーム
+        {{ contest.teams.length }} チーム
       </p>
     </div>
   </router-link>

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -13,6 +13,7 @@ defineProps<Props>()
   <router-link :to="`/contests/${contest.id}/edit`" :class="$style.link">
     <div :class="$style.container">
       <p :class="$style.displayName">{{ contest.name }}</p>
+      <!-- todo:swaggerが直ったらprops.contestからデータを取ってくる -->
       <p :class="$style.duration"><icon name="mdi:calendar" />2020/12/30</p>
       <p :class="$style.teams"><icon name="mdi:account-group" />23チーム</p>
     </div>

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -14,7 +14,6 @@ defineProps<Props>()
   <router-link :to="`/contests/${contest.id}/edit`" :class="$style.link">
     <div :class="$style.container">
       <p :class="$style.name">{{ contest.name }}</p>
-      <!-- todo:swaggerが直ったらprops.contestからデータを取ってくる -->
       <p :class="$style.duration">
         <icon name="mdi:calendar" />
         {{ getFullDayString(new Date(contest.duration.since)) }}

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -12,7 +12,7 @@ defineProps<Props>()
 <template>
   <router-link :to="`/contests/${contest.id}/edit`" :class="$style.link">
     <div :class="$style.container">
-      <p :class="$style.displayName">{{ contest.name }}</p>
+      <p :class="$style.name">{{ contest.name }}</p>
       <!-- todo:swaggerが直ったらprops.contestからデータを取ってくる -->
       <p :class="$style.duration"><icon name="mdi:calendar" />2020/12/30</p>
       <p :class="$style.teams"><icon name="mdi:account-group" />23チーム</p>
@@ -29,7 +29,7 @@ defineProps<Props>()
   padding: 0.5rem;
 }
 
-.displayName {
+.name {
   color: $color-primary;
   font-size: 1.125rem;
 }

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -1,9 +1,10 @@
 <script lang="ts" setup>
-import type { ContestTeamWithContestName } from '/@/lib/apis'
+import type { UserContest } from '/@/lib/apis'
 import Icon from '/@/components/UI/Icon.vue'
+import { getFullDayString } from '/@/lib/date'
 
 interface Props {
-  contest: ContestTeamWithContestName
+  contest: UserContest
 }
 
 defineProps<Props>()
@@ -14,8 +15,14 @@ defineProps<Props>()
     <div :class="$style.container">
       <p :class="$style.name">{{ contest.name }}</p>
       <!-- todo:swaggerが直ったらprops.contestからデータを取ってくる -->
-      <p :class="$style.duration"><icon name="mdi:calendar" />2020/12/30</p>
-      <p :class="$style.teams"><icon name="mdi:account-group" />23チーム</p>
+      <p :class="$style.duration">
+        <icon name="mdi:calendar" />
+        {{ getFullDayString(new Date(contest.duration.since)) }}
+      </p>
+      <p :class="$style.teams">
+        <icon name="mdi:account-group" />
+        {{ contest.teamCount }} チーム
+      </p>
     </div>
   </router-link>
 </template>

--- a/src/components/Contests/ContestItem.vue
+++ b/src/components/Contests/ContestItem.vue
@@ -1,0 +1,47 @@
+<script lang="ts" setup>
+import type { ContestTeamWithContestName } from '/@/lib/apis'
+import Icon from '/@/components/UI/Icon.vue'
+
+interface Props {
+  contest: ContestTeamWithContestName
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  <router-link :to="`/contests/${contest.id}/edit`" :class="$style.link">
+    <div :class="$style.container">
+      <p :class="$style.displayName">{{ contest.name }}</p>
+      <p :class="$style.duration"><icon name="mdi:calendar" />2020/12/30</p>
+      <p :class="$style.teams"><icon name="mdi:account-group" />23チーム</p>
+    </div>
+  </router-link>
+</template>
+
+<style lang="scss" module>
+.link {
+  color: inherit;
+  text-decoration: none;
+}
+.container {
+  padding: 0.5rem;
+}
+
+.displayName {
+  color: $color-primary;
+  font-size: 1.125rem;
+}
+.duration {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+.teams {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+</style>

--- a/src/components/UI/BaseButton.vue
+++ b/src/components/UI/BaseButton.vue
@@ -33,7 +33,7 @@ const props = withDefaults(defineProps<Props>(), {
   align-items: center;
   justify-content: center;
   gap: 4px;
-  padding: 4px 24px;
+  padding: 8px 24px;
   border-radius: 6px; // todo:%で指定に変えるかも
   box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.1);
   transition: 0.2s ease-in-out;

--- a/src/pages/Contests.vue
+++ b/src/pages/Contests.vue
@@ -5,17 +5,17 @@ import BaseButton from '/@/components/UI/BaseButton.vue'
 import ContestItem from '/@/components/Contests/ContestItem.vue'
 
 import { ref } from 'vue'
-import apis from '/@/lib/apis'
-import useUserDataFetcher from '/@/use/userDataFetcher'
 import FormInput from '/@/components/UI/FormInput.vue'
+import { storeToRefs } from 'pinia'
+import { RouterLink } from 'vue-router'
+import { useContestStore } from '/@/store/contest'
 
-const userId = ref('c714a848-2886-4c10-a313-de9bc61cb2bb')
-// todo: get meが実装されたらそれを使う
+const contestStore = useContestStore()
+const { contests } = storeToRefs(contestStore)
 
-const { data: contests, fetcherState } = useUserDataFetcher(userId, userId =>
-  apis.getUserContests(userId)
-)
 const searchQuery = ref('')
+
+contestStore.fetchContests()
 </script>
 
 <template>
@@ -37,13 +37,11 @@ const searchQuery = ref('')
         <BaseButton type="primary" icon="mdi:trophy">New</BaseButton>
       </router-link>
     </div>
-    <ul v-if="fetcherState === 'loaded'" :class="$style.contestList">
+    <ul :class="$style.contestList">
       <li v-for="contest in contests" :key="contest.id">
         <contest-item :contest="contest" />
       </li>
     </ul>
-    <p v-else-if="fetcherState === 'loading'">ローディング中...</p>
-    <p v-else-if="fetcherState === 'error'">エラーが発生しました</p>
   </page-container>
 </template>
 

--- a/src/pages/Contests.vue
+++ b/src/pages/Contests.vue
@@ -29,13 +29,12 @@ const searchQuery = ref('')
     <div :class="$style.searchFormContainer">
       <FormInput
         v-model="searchQuery"
-        :limit="5"
         placeholder="コンテスト名"
         icon="magnify"
         :class="$style.searchForm"
       />
       <router-link to="/contests/new" :class="$style.link">
-        <BaseButton type="primary" icon="mdi:plus">New</BaseButton>
+        <BaseButton type="primary" icon="mdi:trophy">New</BaseButton>
       </router-link>
     </div>
     <ul v-if="fetcherState === 'loaded'" :class="$style.contestList">

--- a/src/pages/Contests.vue
+++ b/src/pages/Contests.vue
@@ -27,15 +27,20 @@ contestStore.fetchContests()
       :class="$style.header"
     />
     <div :class="$style.searchFormContainer">
-      <FormInput
-        v-model="searchQuery"
-        placeholder="コンテスト名"
-        icon="magnify"
-        :class="$style.searchForm"
-      />
-      <router-link to="/contests/new" :class="$style.link">
-        <BaseButton type="primary" icon="mdi:trophy">New</BaseButton>
-      </router-link>
+      <div :class="$style.searchForm">
+        <p :class="$style.searchFormDescriptionText">検索</p>
+        <FormInput
+          v-model="searchQuery"
+          placeholder="コンテスト名"
+          icon="magnify"
+        />
+      </div>
+      <div :class="$style.newContestLink">
+        <p :class="$style.searchFormDescriptionText">コンテスト作成</p>
+        <router-link to="/contests/new" :class="$style.link">
+          <BaseButton type="primary" icon="mdi:trophy">New</BaseButton>
+        </router-link>
+      </div>
     </div>
     <ul :class="$style.contestList">
       <li v-for="contest in contests" :key="contest.id">
@@ -54,13 +59,19 @@ contestStore.fetchContests()
 .header {
   margin: 4rem 0 2rem;
 }
+.searchFormDescriptionText {
+  color: $color-secondary;
+  font-size: 0.875rem;
+}
 .searchForm {
   flex-grow: 1;
+}
+.newContestLink {
+  margin-left: 0.5rem;
 }
 .link {
   text-decoration: none;
   color: inherit;
-  margin-left: 0.5rem;
 }
 .contestList {
   list-style: none;

--- a/src/pages/Contests.vue
+++ b/src/pages/Contests.vue
@@ -1,15 +1,83 @@
+<script lang="ts" setup>
+import ContentHeader from '/@/components/Layout/ContentHeader.vue'
+import PageContainer from '/@/components/Layout/PageContainer.vue'
+import BaseButton from '/@/components/UI/BaseButton.vue'
+import ContestItem from '/@/components/Contests/ContestItem.vue'
+
+import { ref } from 'vue'
+import apis from '/@/lib/apis'
+import useUserDataFetcher from '/@/use/userDataFetcher'
+import FormInput from '/@/components/UI/FormInput.vue'
+
+const userId = ref('c714a848-2886-4c10-a313-de9bc61cb2bb')
+// todo: get meが実装されたらそれを使う
+
+const { data: contests, fetcherState } = useUserDataFetcher(userId, userId =>
+  apis.getUserContests(userId)
+)
+const searchQuery = ref('')
+</script>
+
 <template>
-  <div>Contests</div>
+  <page-container>
+    <content-header
+      icon-name="mdi:trophy"
+      :header-texts="[{ title: 'Contests', url: '/contests' }]"
+      detail="コンテスト情報を変更します。"
+      :class="$style.header"
+    />
+    <div :class="$style.searchFormContainer">
+      <FormInput
+        v-model="searchQuery"
+        :limit="5"
+        placeholder="コンテスト名"
+        icon="magnify"
+        :class="$style.searchForm"
+      />
+      <router-link to="/contests/new" :class="$style.link">
+        <BaseButton type="primary" icon="mdi:plus">New</BaseButton>
+      </router-link>
+    </div>
+    <ul v-if="fetcherState === 'loaded'" :class="$style.contestList">
+      <li v-for="contest in contests" :key="contest.id">
+        <contest-item :contest="contest" />
+      </li>
+    </ul>
+    <p v-else-if="fetcherState === 'loading'">ローディング中...</p>
+    <p v-else-if="fetcherState === 'error'">エラーが発生しました</p>
+  </page-container>
 </template>
 
-<script lang="ts">
-import { defineComponent } from 'vue'
-
-export default defineComponent({
-  name: 'Contests',
-  components: {},
-  setup() {
-    return {}
+<style lang="scss" module>
+.searchFormContainer {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.header {
+  margin: 4rem 0 2rem;
+}
+.searchForm {
+  flex-grow: 1;
+}
+.link {
+  text-decoration: none;
+  color: inherit;
+  margin-left: 0.5rem;
+}
+.contestList {
+  list-style: none;
+  padding: 0.5rem 0;
+  li {
+    border: 1px solid $color-primary-text;
+    border-radius: 8px;
+    margin-bottom: 0.5rem;
+    &:last-child {
+      margin-bottom: 0;
+    }
+    &:hover {
+      background-color: $color-background-dim;
+    }
   }
-})
-</script>
+}
+</style>

--- a/src/pages/Contests.vue
+++ b/src/pages/Contests.vue
@@ -21,7 +21,7 @@ const searchQuery = ref('')
 <template>
   <page-container>
     <content-header
-      icon-name="mdi:trophy"
+      icon-name="mdi:trophy-outline"
       :header-texts="[{ title: 'Contests', url: '/contests' }]"
       detail="コンテスト情報を変更します。"
       :class="$style.header"


### PR DESCRIPTION
close https://github.com/traPtitech/traPortfolio-Dashboard/issues/41, close https://github.com/traPtitech/traPortfolio-Dashboard/issues/5

相談したいこと
- 検索フォームの処理はどのように行う想定ですか？(クエリ渡したらサーバーから配列を返してもらえるようにするのか、クライアントで実装するのか)
- ~~Figmaのデザインで、ボタンコンポーネントは高さ32だったのですが、コンテストページで検索フォームの右に配置されているボタンは高さが40になってしまっていて、どこで合わせようかなーってなってます(アカウントページで使われているボタンは32でした)。ここだけ無理やり40にするか、ボタンコンポーネント自体を40にするか、inputformを32にするか、別の方法でデザインをいい感じにするか、みたいな~~ 完
- ~~`GET users/{userID}/contests`のSwagger・サーバーの実装がバグっていたので(serverチャンネルで報告済み)、修正が入ったらクライアントの方も一部直します~~ 完