### PR TITLE
日付コンポーネントの実装

### DIFF
--- a/src/components/UI/FormDate.vue
+++ b/src/components/UI/FormDate.vue
@@ -1,0 +1,50 @@
+<script lang="ts" setup>
+import Icon from '/@/components/UI/Icon.vue'
+
+interface Props {
+  modelValue: string
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', modelValue: string): void
+}>()
+
+const handleInput = (event: Event) => {
+  emit('update:modelValue', (event.target as HTMLInputElement).value)
+}
+</script>
+
+<template>
+  <div :class="$style.container">
+    <icon name="mdi:calendar-clock" :class="$style.icon" />
+    <input
+      :class="$style.input"
+      type="datetime-local"
+      :value="props.modelValue"
+      @input="handleInput"
+    />
+  </div>
+</template>
+
+<style module lang="scss">
+.container {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid $color-secondary;
+  border-radius: 6px;
+  &:focus-within {
+    border-color: $color-primary;
+  }
+}
+.input {
+  flex-grow: 1;
+}
+.icon {
+  color: $color-secondary;
+  .container:focus-within & {
+    color: $color-primary;
+  }
+}
+</style>

--- a/src/components/UI/FormDate.vue
+++ b/src/components/UI/FormDate.vue
@@ -20,6 +20,7 @@ const handleInput = (event: Event) => {
     <icon name="mdi:calendar-clock" :class="$style.icon" />
     <input
       :class="$style.input"
+      :data-is-blank="props.modelValue === ''"
       type="datetime-local"
       :value="props.modelValue"
       @input="handleInput"
@@ -40,8 +41,12 @@ const handleInput = (event: Event) => {
 }
 .input {
   flex-grow: 1;
+  &[data-is-blank='true'] {
+    color: $color-secondary;
+  }
 }
 .icon {
+  margin-right: 0.25rem;
   color: $color-secondary;
   .container:focus-within & {
     color: $color-primary;

--- a/src/components/UI/FormDuration.vue
+++ b/src/components/UI/FormDuration.vue
@@ -29,7 +29,7 @@ const handleInput = (value: string, dateType: DateType) => {
     <div :class="$style.formDate">
       <div :class="$style.sinceHead">
         <p :class="$style.head">～から</p>
-        <required />
+        <required v-if="sinceRequired" />
       </div>
       <form-date
         :model-value="modelValue.since"

--- a/src/components/UI/FormDuration.vue
+++ b/src/components/UI/FormDuration.vue
@@ -1,11 +1,13 @@
 <script lang="ts" setup>
 import FormDate from '/@/components/UI/FormDate.vue'
 import { Duration } from '/@/lib/apis'
+import Required from '/@/components/UI/Required.vue'
 
 type DateType = 'since' | 'until'
 
 interface Props {
   modelValue: Duration
+  sinceRequired?: boolean
 }
 
 const props = defineProps<Props>()
@@ -25,7 +27,10 @@ const handleInput = (value: string, dateType: DateType) => {
 <template>
   <div :class="$style.container">
     <div :class="$style.formDate">
-      <p :class="$style.body2">～から</p>
+      <div :class="$style.sinceHead">
+        <p :class="$style.head">～から</p>
+        <required />
+      </div>
       <form-date
         :model-value="modelValue.since"
         @update:model-value="handleInput($event, 'since')"
@@ -33,7 +38,9 @@ const handleInput = (value: string, dateType: DateType) => {
     </div>
     <p :class="$style.wave">～</p>
     <div :class="$style.formDate">
-      <p :class="$style.body2">～まで</p>
+      <div :class="$style.untilHead">
+        <p :class="$style.head">～まで</p>
+      </div>
       <form-date
         :model-value="modelValue.until ?? ''"
         @update:model-value="handleInput($event, 'until')"
@@ -48,12 +55,23 @@ const handleInput = (value: string, dateType: DateType) => {
   align-items: flex-end;
   gap: 0.5rem;
 }
+.sinceHead {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+.untilHead {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
 .wave {
   height: 2.75rem;
   display: flex;
   align-items: center;
 }
-.body2 {
-  font-size: 0.875rem;
+.head {
+  font-size: 0.75rem;
 }
 </style>

--- a/src/components/UI/FormDuration.vue
+++ b/src/components/UI/FormDuration.vue
@@ -1,0 +1,59 @@
+<script lang="ts" setup>
+import FormDate from '/@/components/UI/FormDate.vue'
+import { Duration } from '/@/lib/apis'
+
+type DateType = 'since' | 'until'
+
+interface Props {
+  modelValue: Duration
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', modelValue: Duration): void
+}>()
+
+const handleInput = (value: string, dateType: DateType) => {
+  const duration: Duration = {
+    since: dateType === 'since' ? value : props.modelValue.since,
+    until: dateType === 'until' ? value : props.modelValue.until
+  }
+  emit('update:modelValue', duration)
+}
+</script>
+
+<template>
+  <div :class="$style.container">
+    <div :class="$style.formDate">
+      <p :class="$style.body2">～から</p>
+      <form-date
+        :model-value="modelValue.since"
+        @update:model-value="handleInput($event, 'since')"
+      />
+    </div>
+    <p :class="$style.wave">～</p>
+    <div :class="$style.formDate">
+      <p :class="$style.body2">～まで</p>
+      <form-date
+        :model-value="modelValue.until ?? ''"
+        @update:model-value="handleInput($event, 'until')"
+      />
+    </div>
+  </div>
+</template>
+
+<style module lang="scss">
+.container {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+}
+.wave {
+  height: 2.75rem;
+  display: flex;
+  align-items: center;
+}
+.body2 {
+  font-size: 0.875rem;
+}
+</style>


### PR DESCRIPTION
sinceとuntilがセットで使われていることが多そうなので、単体コンポーネントを2つ使ってセットのも作りました
必須アイコンはsinceのみの場合は「～から」の横に、sinceもuntilもの場合は「日時」の横につけていそうなので、sinceのみの場合だけ対応しました(untilのみの場合は存在しないはず)
`formDuration`は以下のような感じで動くと思います(`formDate`はstring型の変数で`v-model`使うだけです)

```
<script lang="ts" setup>
import PageContainer from '/@/components/Layout/PageContainer.vue'
import FormDuration from '/@/components/UI/FormDuration.vue'
import { ref } from 'vue'
import { Duration } from '/@/lib/apis'

const value = ref<Duration>({ since: '', until: '' })
</script>

<template>
  <page-container>
    <form-duration v-model="value" />
  </page-container>
</template>
```