### PR TITLE
🐛 contest 個別ページでの ID 取得ができていなかった

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -54,7 +54,7 @@ const routes = [
     component: Contests
   },
   {
-    path: '/contests/:id',
+    path: '/contests/:contestId',
     name: 'Contest',
     component: Contest
   },


### PR DESCRIPTION
`router.ts` 上では `:id` で持っていたのを `src/pages/Contest.vue` 内では `contestId` で参照していた

`/contests/` 以下に合わせて `router.ts` 内のを `courceId` に揃えました