### PR TITLE
Event と Services 周りのリファクタ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "ts-morph": "^20.0.0",
         "typescript": "^5.2.2",
         "vite": "^4.4.11",
-        "vite-plugin-purge-icons": "^0.9.2"
+        "vite-plugin-purge-icons": "^0.9.2",
+        "vue-tsc": "1.8.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1828,6 +1829,33 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@volar/language-core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.7.6.tgz",
+      "integrity": "sha512-r+82YGjae8ALzaX+TaESpeBOrp/H5MQnPYZLq4WKd8rsPrCAPbMwelwHLHhFpyjy66BK/cKreJAcvOc6YEwyFA==",
+      "dev": true,
+      "dependencies": {
+        "@volar/source-map": "1.7.6"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.7.6.tgz",
+      "integrity": "sha512-6oGrgz+hg5GCzP8D2+ay7vOdIOA9/aXwpa22Wx5b6d4ZGwwosBqv7kVs8AyMh5zOSQpKhrImE1pfagpu+V+rBQ==",
+      "dev": true,
+      "dependencies": {
+        "muggle-string": "^0.3.1"
+      }
+    },
+    "node_modules/@volar/typescript": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.7.6.tgz",
+      "integrity": "sha512-JkBRQe2GYSEgamW84tDk4XQ/7abQJw09czLQCgL1jfjndhaV4DuAet2I3pvQv41OjodVc59W0+E3hylrlNsgWA==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.7.6"
+      }
+    },
     "node_modules/@vue/compiler-core": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
@@ -1878,6 +1906,54 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
       "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+    },
+    "node_modules/@vue/language-core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.0.tgz",
+      "integrity": "sha512-rOAtqIRyyZ6OQreAkFDbbDt7L5BwvzrdbWaBAoEZjr4ImPBV9cRDBHxlMBU0SBOAZxIUQdjOvQ0uAl9uZDer0w==",
+      "dev": true,
+      "dependencies": {
+        "@volar/language-core": "1.7.6",
+        "@volar/source-map": "1.7.6",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/reactivity": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "minimatch": "^9.0.0",
+        "muggle-string": "^0.3.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@vue/language-core/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@vue/reactivity": {
       "version": "3.3.4",
@@ -1934,6 +2010,16 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+    },
+    "node_modules/@vue/typescript": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.0.tgz",
+      "integrity": "sha512-swi0NM+dpZCldXkMGS8wCxvoiRgA0PJw0UQeSTA7PqB2/5LsOQ8pmxyqLPE6YsbEdn0XqI9a7QgKOmmElkaMOA==",
+      "dev": true,
+      "dependencies": {
+        "@volar/typescript": "1.7.6",
+        "@vue/language-core": "1.8.0"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -2765,6 +2851,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
       }
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3730,6 +3822,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -4550,6 +4651,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/muggle-string": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "node_modules/mute-stream": {
@@ -6092,6 +6199,12 @@
         "vite": "^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/vscode-uri": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+      "dev": true
+    },
     "node_modules/vue": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
@@ -6150,12 +6263,40 @@
         "vue": "3.x"
       }
     },
+    "node_modules/vue-template-compiler": {
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
+      "dev": true,
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
     "node_modules/vue-toastification": {
       "version": "2.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
       "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
       "peerDependencies": {
         "vue": "^3.0.2"
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.0.tgz",
+      "integrity": "sha512-zRjRghohec71o+o3dzzqwFLtbKmJ1K1xRnq9ToHRdnHbBSZA2eUaTT1o+y4xOkBLZtW4cv7FkZE0FGCZfMrcBw==",
+      "dev": true,
+      "dependencies": {
+        "@vue/language-core": "1.8.0",
+        "@vue/typescript": "1.8.0",
+        "semver": "^7.3.8",
+        "vscode-uri": "^3.0.7"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": "*"
       }
     },
     "node_modules/wcwidth": {
@@ -7585,6 +7726,33 @@
       "dev": true,
       "requires": {}
     },
+    "@volar/language-core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-1.7.6.tgz",
+      "integrity": "sha512-r+82YGjae8ALzaX+TaESpeBOrp/H5MQnPYZLq4WKd8rsPrCAPbMwelwHLHhFpyjy66BK/cKreJAcvOc6YEwyFA==",
+      "dev": true,
+      "requires": {
+        "@volar/source-map": "1.7.6"
+      }
+    },
+    "@volar/source-map": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-1.7.6.tgz",
+      "integrity": "sha512-6oGrgz+hg5GCzP8D2+ay7vOdIOA9/aXwpa22Wx5b6d4ZGwwosBqv7kVs8AyMh5zOSQpKhrImE1pfagpu+V+rBQ==",
+      "dev": true,
+      "requires": {
+        "muggle-string": "^0.3.1"
+      }
+    },
+    "@volar/typescript": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-1.7.6.tgz",
+      "integrity": "sha512-JkBRQe2GYSEgamW84tDk4XQ/7abQJw09czLQCgL1jfjndhaV4DuAet2I3pvQv41OjodVc59W0+E3hylrlNsgWA==",
+      "dev": true,
+      "requires": {
+        "@volar/language-core": "1.7.6"
+      }
+    },
     "@vue/compiler-core": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
@@ -7635,6 +7803,42 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.0.tgz",
       "integrity": "sha512-o9KfBeaBmCKl10usN4crU53fYtC1r7jJwdGKjPT24t348rHxgfpZ0xL3Xm/gLUYnc0oTp8LAmrxOeLyu6tbk2Q=="
+    },
+    "@vue/language-core": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-1.8.0.tgz",
+      "integrity": "sha512-rOAtqIRyyZ6OQreAkFDbbDt7L5BwvzrdbWaBAoEZjr4ImPBV9cRDBHxlMBU0SBOAZxIUQdjOvQ0uAl9uZDer0w==",
+      "dev": true,
+      "requires": {
+        "@volar/language-core": "1.7.6",
+        "@volar/source-map": "1.7.6",
+        "@vue/compiler-dom": "^3.3.0",
+        "@vue/reactivity": "^3.3.0",
+        "@vue/shared": "^3.3.0",
+        "minimatch": "^9.0.0",
+        "muggle-string": "^0.3.1",
+        "vue-template-compiler": "^2.7.14"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
     },
     "@vue/reactivity": {
       "version": "3.3.4",
@@ -7688,6 +7892,16 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ=="
+    },
+    "@vue/typescript": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@vue/typescript/-/typescript-1.8.0.tgz",
+      "integrity": "sha512-swi0NM+dpZCldXkMGS8wCxvoiRgA0PJw0UQeSTA7PqB2/5LsOQ8pmxyqLPE6YsbEdn0XqI9a7QgKOmmElkaMOA==",
+      "dev": true,
+      "requires": {
+        "@volar/typescript": "1.7.6",
+        "@vue/language-core": "1.8.0"
+      }
     },
     "abstract-logging": {
       "version": "2.0.1",
@@ -8277,6 +8491,12 @@
       "requires": {
         "@babel/runtime": "^7.21.0"
       }
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
     },
     "debug": {
       "version": "4.3.4",
@@ -8981,6 +9201,12 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "http-proxy-agent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
@@ -9612,6 +9838,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "muggle-string": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.3.1.tgz",
+      "integrity": "sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==",
       "dev": true
     },
     "mute-stream": {
@@ -10682,6 +10914,12 @@
         "rollup-plugin-purge-icons": "^0.9.1"
       }
     },
+    "vscode-uri": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+      "dev": true
+    },
     "vue": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
@@ -10723,11 +10961,33 @@
       "integrity": "sha512-W9alTe9NwVn2GR9QFW5CbrX47yghEaJCpUVs9JTv9Q7CWmsNPp5kIlETdke4aFHphZvyjDUlyvH/7/8XzfVZkw==",
       "requires": {}
     },
+    "vue-template-compiler": {
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.15.tgz",
+      "integrity": "sha512-yQxjxMptBL7UAog00O8sANud99C6wJF+7kgbcwqkvA38vCGF7HWE66w0ZFnS/kX5gSoJr/PQ4/oS3Ne2pW37Og==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
     "vue-toastification": {
       "version": "2.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/vue-toastification/-/vue-toastification-2.0.0-rc.5.tgz",
       "integrity": "sha512-q73e5jy6gucEO/U+P48hqX+/qyXDozAGmaGgLFm5tXX4wJBcVsnGp4e/iJqlm9xzHETYOilUuwOUje2Qg1JdwA==",
       "requires": {}
+    },
+    "vue-tsc": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-1.8.0.tgz",
+      "integrity": "sha512-zRjRghohec71o+o3dzzqwFLtbKmJ1K1xRnq9ToHRdnHbBSZA2eUaTT1o+y4xOkBLZtW4cv7FkZE0FGCZfMrcBw==",
+      "dev": true,
+      "requires": {
+        "@vue/language-core": "1.8.0",
+        "@vue/typescript": "1.8.0",
+        "semver": "^7.3.8",
+        "vscode-uri": "^3.0.7"
+      }
     },
     "wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "lint": "eslint --fix --ext .ts,.vue src",
     "lint:nofix": "eslint --ext .ts,.vue src",
-    "type-check": "tsc",
+    "type-check": "vue-tsc --noEmit",
     "fetch-openapi": "node scripts/fetchOpenapi.js",
     "gen-api": "node scripts/generateApi.js",
     "start-mock": "prism mock -p 4010 -d scripts/traPortfolio.v1.yaml",
@@ -45,7 +45,8 @@
     "ts-morph": "^20.0.0",
     "typescript": "^5.2.2",
     "vite": "^4.4.11",
-    "vite-plugin-purge-icons": "^0.9.2"
+    "vite-plugin-purge-icons": "^0.9.2",
+    "vue-tsc": "1.8.0"
   },
   "private": true
 }

--- a/src/components/UI/AutoResizeTextArea.vue
+++ b/src/components/UI/AutoResizeTextArea.vue
@@ -2,11 +2,9 @@
 import {
   nextTick,
   watch,
-  defineProps,
   onMounted,
   ref,
   toRef,
-  withDefaults,
   computed,
   onBeforeUnmount
 } from 'vue'

--- a/src/components/UI/ServiceAccordion.vue
+++ b/src/components/UI/ServiceAccordion.vue
@@ -1,7 +1,11 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
 import BaseSelect from '/@/components/UI/BaseSelect.vue'
-import { services, serviceNameToType, serviceArray } from '/@/consts/services'
+import {
+  serviceNameToType,
+  serviceArray,
+  serviceTypeToNameMap
+} from '/@/consts/services'
 import { AccountType } from '/@/lib/apis'
 
 interface Props {
@@ -17,7 +21,7 @@ const emit = defineEmits<{
 }>()
 
 const value = computed({
-  get: () => services.get(props.modelValue)?.name ?? '',
+  get: () => serviceTypeToNameMap[props.modelValue],
   set: v =>
     emit('update:modelValue', serviceNameToType(v) ?? AccountType.homepage)
 })

--- a/src/components/UserAccounts/ServiceLogo.vue
+++ b/src/components/UserAccounts/ServiceLogo.vue
@@ -1,19 +1,22 @@
 <script lang="ts" setup>
 import Icon from '/@/components/UI/Icon.vue'
 import type { AccountType } from '/@/lib/apis'
-import { services } from '/@/consts/services'
+import { services, serviceTypeToNameMap } from '/@/consts/services'
+import { computed } from 'vue'
 
 interface Props {
   service: AccountType
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const serviceName = computed(() => serviceTypeToNameMap[props.service])
 </script>
 
 <template>
   <div :class="$style.logo">
-    <icon :name="services.get(service)?.icon ?? ''" />
-    {{ services.get(service)?.name }}
+    <icon :name="services[serviceName].icon" />
+    {{ serviceName }}
   </div>
 </template>
 

--- a/src/components/Users/UserAccounts.vue
+++ b/src/components/Users/UserAccounts.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import Icon from '/@/components/UI/Icon.vue'
-import { serviceArray, type ServiceWithType } from '/@/consts/services'
+import { serviceArray, type ServiceWithName } from '/@/consts/services'
 import type { Account } from '/@/lib/apis'
 
-interface Service extends ServiceWithType {
+interface Service extends ServiceWithName {
   url: string | undefined
   displayName: string | undefined
 }

--- a/src/consts/eventLevel.ts
+++ b/src/consts/eventLevel.ts
@@ -1,47 +1,45 @@
 import { EventLevel } from '/@/lib/apis'
 
-export type EventLevelValue = 'public' | 'anonymous' | 'private'
+export const eventLevelValueMap = Object.freeze({
+  [EventLevel.Public]: 'public',
+  [EventLevel.Anonymous]: 'anonymous',
+  [EventLevel.Private]: 'private'
+}) satisfies Record<EventLevel, string>
 
-interface EventLevelDetail {
+type EventLevelValueMap = typeof eventLevelValueMap
+
+export type EventLevelValue = EventLevelValueMap[keyof EventLevelValueMap]
+
+interface EventLevelDetail<Level extends EventLevel = EventLevel> {
   label: string
-  value: EventLevelValue
+  value: Level
   description: string
 }
 
-type EventLevelMap = Map<EventLevel, EventLevelDetail>
+type EventLevelMap = {
+  [K in EventLevel as EventLevelValueMap[K]]: EventLevelDetail<K>
+}
 
-export const eventLevels: EventLevelMap = new Map([
-  [
-    EventLevel.Public,
-    {
-      label: '公開',
-      value: 'public',
-      description: 'ポートフォリオにて公開します'
-    }
-  ],
-  [
-    EventLevel.Anonymous,
-    {
-      label: '匿名公開',
-      value: 'anonymous',
-      description: '企画者の名前を伏せて、ポートフォリオにて公開します'
-    }
-  ],
-  [
-    EventLevel.Private,
-    {
-      label: '非公開',
-      value: 'private',
-      description: 'ポートフォリオにて公開しません'
-    }
-  ]
-])
+export const eventLevels = Object.freeze({
+  public: {
+    label: '公開',
+    value: EventLevel.Public,
+    description: 'ポートフォリオにて公開します'
+  },
+  anonymous: {
+    label: '匿名公開',
+    value: EventLevel.Anonymous,
+    description: '企画者の名前を伏せて、ポートフォリオにて公開します'
+  },
+  private: {
+    label: '非公開',
+    value: EventLevel.Private,
+    description: 'ポートフォリオにて公開しません'
+  }
+}) as EventLevelMap
 
 export const getEventLevelFromValue = (
-  value: string
-): EventLevel | undefined => {
-  const entry = Array.from(eventLevels).find(
-    ([, service]) => service.value === value
-  )
-  return entry?.[0]
+  value: EventLevelValue
+): EventLevel => {
+  return eventLevels[value].value
 }

--- a/src/consts/eventLevel.ts
+++ b/src/consts/eventLevel.ts
@@ -36,7 +36,7 @@ export const eventLevels = Object.freeze({
     value: EventLevel.Private,
     description: 'ポートフォリオにて公開しません'
   }
-}) as EventLevelMap
+}) satisfies EventLevelMap
 
 export const getEventLevelFromValue = (
   value: EventLevelValue

--- a/src/consts/eventLevel.ts
+++ b/src/consts/eventLevel.ts
@@ -1,3 +1,4 @@
+import { deepFreeze } from '/@/lib/deepFreeze'
 import { EventLevel } from '/@/lib/apis'
 
 export const eventLevelValueMap = Object.freeze({
@@ -20,7 +21,7 @@ type EventLevelMap = {
   [K in EventLevel as EventLevelValueMap[K]]: EventLevelDetail<K>
 }
 
-export const eventLevels = Object.freeze({
+export const eventLevels = deepFreeze({
   public: {
     label: '公開',
     value: EventLevel.Public,

--- a/src/consts/eventLevel.ts
+++ b/src/consts/eventLevel.ts
@@ -1,6 +1,6 @@
 import { EventLevel } from '/@/lib/apis'
 
-type EventLevelValue = 'public' | 'anonymous' | 'private'
+export type EventLevelValue = 'public' | 'anonymous' | 'private'
 
 interface EventLevelDetail {
   label: string

--- a/src/consts/services.ts
+++ b/src/consts/services.ts
@@ -87,7 +87,7 @@ export const serviceArray: readonly ServiceWithName[] = Object.entries(
   services
 ).map(([name, service]) => ({
   ...service,
-  name: name as ServiceName
+  name: name as keyof typeof services
 }))
 
 export const serviceNameToType = (name: ServiceName): AccountType => {

--- a/src/consts/services.ts
+++ b/src/consts/services.ts
@@ -1,3 +1,4 @@
+import { deepFreeze } from '/@/lib/deepFreeze'
 import { AccountType } from '/@/lib/apis'
 
 export interface Service<Type extends AccountType = AccountType> {
@@ -31,7 +32,7 @@ type ServiceRecord = {
   [Type in AccountType as ServiceTypeToName[Type]]: Service<Type>
 }
 
-export const services = Object.freeze({
+export const services = deepFreeze({
   HomePage: {
     icon: 'mdi:home',
     type: AccountType.homepage

--- a/src/consts/services.ts
+++ b/src/consts/services.ts
@@ -1,111 +1,96 @@
 import { AccountType } from '/@/lib/apis'
 
-interface Service {
-  name: string
+export interface Service<Type extends AccountType = AccountType> {
   icon: string
-}
-export interface ServiceWithType extends Service {
-  type: AccountType
+  type: Type
 }
 
-type ServiceRecord = Map<AccountType, Service>
+export interface ServiceWithName<Type extends AccountType = AccountType>
+  extends Service<Type> {
+  name: ServiceName
+}
 
-export const services: ServiceRecord = new Map([
-  [
-    AccountType.homepage,
-    {
-      name: 'HomePage',
-      icon: 'mdi:home'
-    }
-  ],
-  [
-    AccountType.blog,
-    {
-      name: 'Blog',
-      icon: 'mdi:post-outline'
-    }
-  ],
-  [
-    AccountType.twitter,
-    {
-      name: 'Twitter',
-      icon: 'mdi:twitter'
-    }
-  ],
-  [
-    AccountType.facebook,
-    {
-      name: 'Facebook',
-      icon: 'mdi:facebook'
-    }
-  ],
-  [
-    AccountType.pixiv,
-    {
-      name: 'pixiv',
-      icon: 'simple-icons:pixiv'
-    }
-  ],
-  [
-    AccountType.github,
-    {
-      name: 'Github',
-      icon: 'mdi:github'
-    }
-  ],
-  [
-    AccountType.qiita,
-    {
-      name: 'Qiita',
-      icon: 'simple-icons:qiita'
-    }
-  ],
-  [
-    AccountType.zenn,
-    {
-      name: 'Zenn',
-      icon: 'simple-icons:zenn'
-    }
-  ],
-  [
-    AccountType.atcoder,
-    {
-      name: 'AtCoder',
-      icon: 'atcoder' //アイコンは保留
-    }
-  ],
-  [
-    AccountType.soundcloud,
-    {
-      name: 'SoundCloud',
-      icon: 'mdi:soundcloud'
-    }
-  ],
-  [
-    AccountType.hackthebox,
-    {
-      name: 'HackTheBox',
-      icon: 'simple-icons:hackthebox'
-    }
-  ],
-  [
-    AccountType.ctftime,
-    {
-      name: 'CTFtime',
-      icon: 'ctftime' //アイコンは保留
-    }
-  ]
-])
+export const serviceTypeToNameMap = Object.freeze({
+  [AccountType.homepage]: 'HomePage',
+  [AccountType.blog]: 'Blog',
+  [AccountType.twitter]: 'Twitter',
+  [AccountType.facebook]: 'Facebook',
+  [AccountType.pixiv]: 'pixiv',
+  [AccountType.github]: 'Github',
+  [AccountType.qiita]: 'Qiita',
+  [AccountType.zenn]: 'Zenn',
+  [AccountType.atcoder]: 'AtCoder',
+  [AccountType.soundcloud]: 'SoundCloud',
+  [AccountType.hackthebox]: 'HackTheBox',
+  [AccountType.ctftime]: 'CTFtime'
+}) satisfies Record<AccountType, string>
 
-export const serviceArray: ServiceWithType[] = Array.from(
-  services.entries()
-).map(([type, service]) => ({ ...service, type }))
+type ServiceTypeToName = typeof serviceTypeToNameMap
+type ServiceName = ServiceTypeToName[keyof ServiceTypeToName]
+type ServiceRecord = {
+  [Type in AccountType as ServiceTypeToName[Type]]: Service<Type>
+}
 
-export const serviceNameToType = (name: string): AccountType | undefined => {
-  const entry = Array.from(services).find(
-    ([, service]) => service.name === name
-  )
-  return entry?.[0]
+export const services = Object.freeze({
+  HomePage: {
+    icon: 'mdi:home',
+    type: AccountType.homepage
+  },
+  Blog: {
+    icon: 'mdi:post-outline',
+    type: AccountType.blog
+  },
+  Twitter: {
+    icon: 'mdi:twitter',
+    type: AccountType.twitter
+  },
+  Facebook: {
+    icon: 'mdi:facebook',
+    type: AccountType.facebook
+  },
+  pixiv: {
+    icon: 'simple-icons:pixiv',
+    type: AccountType.pixiv
+  },
+  Github: {
+    icon: 'mdi:github',
+    type: AccountType.github
+  },
+  Qiita: {
+    icon: 'simple-icons:qiita',
+    type: AccountType.qiita
+  },
+  Zenn: {
+    icon: 'simple-icons:zenn',
+    type: AccountType.zenn
+  },
+  AtCoder: {
+    icon: 'atcoder', //アイコンは保留
+    type: AccountType.atcoder
+  },
+  SoundCloud: {
+    icon: 'mdi:soundcloud',
+    type: AccountType.soundcloud
+  },
+  HackTheBox: {
+    icon: 'simple-icons:hackthebox',
+    type: AccountType.hackthebox
+  },
+  CTFtime: {
+    icon: 'ctftime', //アイコンは保留
+    type: AccountType.ctftime
+  }
+}) satisfies ServiceRecord
+
+export const serviceArray: readonly ServiceWithName[] = Object.entries(
+  services
+).map(([name, service]) => ({
+  ...service,
+  name: name as ServiceName
+}))
+
+export const serviceNameToType = (name: ServiceName): AccountType => {
+  return services[name].type
 }
 export const hasIdService = (type: AccountType) =>
   ![AccountType.homepage, AccountType.blog].includes(type)

--- a/src/lib/deepFreeze.ts
+++ b/src/lib/deepFreeze.ts
@@ -1,3 +1,10 @@
+/**
+ * オブジェクトや配列の全てのプロパティを再帰的にfreezeする
+ *
+ * 自己参照など閉路が存在する場合は無限ループに陥るので注意
+ *
+ * @see https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
+ */
 export const deepFreeze = <const T extends object>(obj: T): T => {
   const propNames = Object.getOwnPropertyNames(obj)
 

--- a/src/lib/deepFreeze.ts
+++ b/src/lib/deepFreeze.ts
@@ -1,0 +1,13 @@
+export const deepFreeze = <const T extends object>(obj: T): T => {
+  const propNames = Object.getOwnPropertyNames(obj)
+
+  for (const name of propNames) {
+    const value = obj[name as keyof typeof obj]
+
+    if (value && typeof value === 'object') {
+      deepFreeze(value as Record<string, unknown>)
+    }
+  }
+
+  return Object.freeze(obj)
+}

--- a/src/pages/Event.vue
+++ b/src/pages/Event.vue
@@ -11,7 +11,10 @@ import useParam from '/@/use/param'
 import { ref } from 'vue'
 import { useToast } from 'vue-toastification'
 import RadioButton from '/@/components/UI/RadioButton.vue'
-import { eventLevels, getEventLevelFromValue } from '/@/consts/eventLevel'
+import {
+  eventLevelValueMap,
+  getEventLevelFromValue
+} from '/@/consts/eventLevel'
 import { EventLevelValue } from '/@/consts/eventLevel'
 
 const router = useRouter()
@@ -20,9 +23,7 @@ const toast = useToast()
 const eventId = useParam('id')
 const event: EventDetail = (await apis.getEvent(eventId.value)).data
 
-const eventLevel = ref<EventLevelValue>(
-  eventLevels.get(event.eventLevel)?.value ?? 'public'
-)
+const eventLevel = ref<EventLevelValue>(eventLevelValueMap[event.eventLevel])
 
 const isSending = ref(false)
 const updateEvent = async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,6 @@
     "lib": ["esnext", "dom", "dom.iterable"],
     "skipLibCheck": true,
     "noEmit": true,
-    "incremental": true,
-    "tsBuildInfoFile": "./node_modules/.tsbuildinfo",
     "typeRoots": ["node_modules/@types", "src/types"],
     "paths": {
       "/@/*": ["src/*"]


### PR DESCRIPTION
- `src/consts/eventLevel.ts` と `src/consts/services.ts` で Map を使って `enum -> value (include name)` していた部分を `enum -> name` と `name -> value (include enum)` のオブジェクト２つにしてそれを使うように
- vue-tsc を入れる
  - vue-tsc が新しい際に npm で動かないバグが有るため、あえて古いバージョンを使っています
      ref: https://github.com/vuejs/language-tools/issues/3317
  - tsconfig の tsbuildinfo があると動かなくなるときがあるので、incremental ごと消した
        ref: https://github.com/microsoft/TypeScript/issues/54057
- vue-tsc 入れるに当たって出ていた型エラーを修正