### PR TITLE
この状態で絶対パスにするとcss,jsの読み込み位置が正常化されそう

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -101,6 +101,6 @@ const routes = [
 ]
 
 export default createRouter({
-  history: createWebHistory('/admin'),
+  history: createWebHistory(),
   routes
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,6 @@ import PurgeIcons from 'vite-plugin-purge-icons'
 const srcPath = path.resolve(__dirname, 'src').replace(/\\/g, '/')
 
 const config: UserConfig = {
-  base: './',
   resolve: {
     alias: {
       '/@': srcPath


### PR DESCRIPTION
相対パスだと下の階層でおかしくなるのでルートの絶対パスで固定します