### PR TITLE
型をいい感じにして空配列を渡したときにエラーにならないように

### DIFF
--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,17 +1,12 @@
-export const searchListCaseInsensitive = <T>(
+export const searchListCaseInsensitive = <
+  K extends string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Index signature for type 'string' is missing in type を回避
+  T extends Record<K, string> & Record<PropertyKey, any>
+>(
   list: T[],
   _query: string,
-  key: keyof T
+  key: K
 ): T[] => {
-  const value = list[0]?.[key]
-  if (typeof value !== 'string') {
-    throw new Error(
-      `The value corresponds to a given key ${key.toString()} must be string`
-    )
-  }
   const query = _query.toLowerCase()
-  // valueがstringなので、item[key]もstringなはず
-  return list.filter(item =>
-    (item[key] as string).toLowerCase().includes(query)
-  )
+  return list.filter(item => item[key].toLowerCase().includes(query))
 }


### PR DESCRIPTION
close https://github.com/traPtitech/traPortfolio-Dashboard/issues/227
typescriptに敗北したのでany使ってます
open-apiの型定義がinterfaceじゃなくてtype aliasだったらエラーにならないらしいけどなんでinterfaceだとエラーになるのかよく分かってない
多分これ: https://github.com/microsoft/TypeScript/issues/50087