### PR TITLE
スマホでtraPのロゴをちょっと小さく

### DIFF
--- a/src/components/Layout/PageHeader.vue
+++ b/src/components/Layout/PageHeader.vue
@@ -34,8 +34,7 @@ const { isMobile } = storeToRefs(useResponsiveStore())
 <style lang="scss" module>
 .container {
   display: flex;
-  height: 5rem;
-  padding: 0 1rem;
+  padding: 1rem 1rem;
   align-items: center;
   border-bottom: solid 0.1rem $color-secondary;
   gap: 1rem;
@@ -43,7 +42,7 @@ const { isMobile } = storeToRefs(useResponsiveStore())
 
 @media (width <= 768px) {
   .container {
-    padding: 0 1rem;
+    padding: 0.25rem 1rem;
   }
 }
 </style>

--- a/src/components/Layout/PageHeader.vue
+++ b/src/components/Layout/PageHeader.vue
@@ -24,7 +24,7 @@ const { isMobile } = storeToRefs(useResponsiveStore())
       <img
         src="/@/assets/traP_logo_blue.svg"
         alt="traP"
-        width="343"
+        :width="!isMobile ? '343' : '240'"
         height="48"
       />
     </router-link>

--- a/src/components/Layout/PageHeader.vue
+++ b/src/components/Layout/PageHeader.vue
@@ -34,7 +34,7 @@ const { isMobile } = storeToRefs(useResponsiveStore())
 <style lang="scss" module>
 .container {
   display: flex;
-  padding: 1rem 1rem;
+  padding: 1rem;
   align-items: center;
   border-bottom: solid 0.1rem $color-secondary;
   gap: 1rem;


### PR DESCRIPTION
close https://github.com/traPtitech/traPortfolio-Dashboard/issues/214

ロゴ自体変えようと思ってたけどサイズ変えるだけで十分そうだった
![image](https://github.com/traPtitech/traPortfolio-Dashboard/assets/83744975/4c68ebd8-6c6c-47a0-92b2-8f8cf90442c7)
