### PR TITLE
「traP広報にて言及を許可」表示を削除

### DIFF
--- a/src/components/UserAccounts/AccountItem.vue
+++ b/src/components/UserAccounts/AccountItem.vue
@@ -21,13 +21,6 @@ defineProps<Props>()
         <service-logo :service="account.type" />
       </div>
       <p :class="$style.url"><icon name="mdi:link" />{{ account.url }}</p>
-      <p :class="$style.prPermission">
-        <icon v-if="account.prPermitted" name="mdi:advertisements" />
-        <icon v-else name="mdi:advertisements-off" />
-        <span>
-          traP広報にて言及を許可{{ account.prPermitted ? 'する' : 'しない' }}
-        </span>
-      </p>
     </div>
   </router-link>
 </template>
@@ -60,11 +53,5 @@ defineProps<Props>()
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-.prPermission {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
 }
 </style>


### PR DESCRIPTION
### **User description**
close #328


___

### **PR Type**
Bug fix


___

### **Description**
- 「traP広報にて言及を許可」表示を削除し、関連するCSSスタイルも削除しました。
- これにより、ユーザーアカウントの表示が簡素化されます。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AccountItem.vue</strong><dd><code>「traP広報にて言及を許可」表示とスタイルの削除</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/UserAccounts/AccountItem.vue

- 「traP広報にて言及を許可」表示を削除
- 関連するCSSスタイルを削除



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/335/files#diff-80a079fa83e99b29e618528a6dd3f03447bdfaed58415e39240d7fcb39157cef">+0/-13</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

