### PR TITLE
UserIconにalt, width, heightをつけた

### DIFF
--- a/src/components/UI/UserIcon.vue
+++ b/src/components/UI/UserIcon.vue
@@ -16,7 +16,14 @@ const styles = computed(() => ({
 </script>
 
 <template>
-  <img :class="$style.icon" :src="src" :style="styles" />
+  <img
+    :class="$style.icon"
+    :src="src"
+    :style="styles"
+    :width="size"
+    :height="size"
+    :alt="userName"
+  />
 </template>
 
 <style lang="scss" module>


### PR DESCRIPTION
### **User description**
close #292 
CLSを防ぐ、改善する原理がわからなかったので、ひとまずUIの方と同じようにしました


___

### **PR Type**
Enhancement


___

### **Description**
- `UserIcon`コンポーネントの`img`タグに`alt`、`width`、`height`属性を追加しました。
- `width`と`height`属性は`size`プロパティを使用し、画像のサイズを指定します。
- `alt`属性は`userName`プロパティを使用し、画像の代替テキストを指定します。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UserIcon.vue</strong><dd><code>`UserIcon`コンポーネントに画像属性を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/UI/UserIcon.vue

<li><code>img</code>タグに<code>width</code>、<code>height</code>、<code>alt</code>属性を追加<br> <li> <code>width</code>と<code>height</code>は<code>size</code>プロパティを使用<br> <li> <code>alt</code>は<code>userName</code>プロパティを使用<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/350/files#diff-bf21cc70f86eef98d4691287e37c492ccbcba89fd26186bf6d6d3cf6291d00d3">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

