### PR TITLE
`FROM` `AS` で大文字に統一

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM node:20.11.1-alpine as build
+FROM --platform=$BUILDPLATFORM node:20.11.1-alpine AS build
 WORKDIR /app
 
 RUN apk update


### PR DESCRIPTION
### **User description**
タイトルのとおりです
確認をお願いします

参考: https://docs.docker.com/reference/build-checks/from-as-casing/


___

### **PR Type**
enhancement


___

### **Description**
- `FROM` statement in the Dockerfile updated to use uppercase `AS` for consistency.
- Aligns with Docker's recommended casing practices.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Standardize casing of `AS` in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li><code>as</code> changed to <code>AS</code> for consistency.<br> <li> Ensures uniform casing in the <code>FROM</code> statement.<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/352/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

