### PR TITLE
コンテスト・プロジェクト編集画面にplaceholderを追加

### DIFF
--- a/src/pages/ContestEdit.vue
+++ b/src/pages/ContestEdit.vue
@@ -124,7 +124,11 @@ const deleteContest = async () => {
         </field-error-message>
       </labeled-form>
       <labeled-form label="リンク" :class="$style.labeledForm">
-        <form-input v-model="formValues.link" has-anchor />
+        <form-input
+          v-model="formValues.link"
+          has-anchor
+          placeholder="https://"
+        />
       </labeled-form>
       <labeled-form required label="説明" :class="$style.labeledForm">
         <form-text-area

--- a/src/pages/Project.vue
+++ b/src/pages/Project.vue
@@ -138,7 +138,11 @@ const handleDelete = (id: string) => {
         </field-error-message>
       </labeled-form>
       <labeled-form label="リンク" :class="$style.labeledForm">
-        <form-input v-model="formValues.link" has-anchor />
+        <form-input
+          v-model="formValues.link"
+          has-anchor
+          placeholder="https://"
+        />
       </labeled-form>
       <labeled-form required label="説明" :class="$style.labeledForm">
         <form-text-area


### PR DESCRIPTION
### **User description**
close #294 
コンテスト・プロジェクト編集画面にplaceholderを追加した


___

### **PR Type**
enhancement


___

### **Description**
- コンテスト編集画面のリンク入力フィールドに`placeholder`を追加し、ユーザーがURLを入力しやすくしました。
- プロジェクト画面のリンク入力フィールドにも同様に`placeholder`を追加しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ContestEdit.vue</strong><dd><code>コンテスト編集画面にリンクフィールドのプレースホルダーを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/ContestEdit.vue

- `placeholder`属性をリンク入力フィールドに追加
- `placeholder`の値は"https://"に設定



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/360/files#diff-6b345b9b3a019b15846536d31ccad1be7489f3dcc49e2f18453e8701556194be">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Project.vue</strong><dd><code>プロジェクト画面にリンクフィールドのプレースホルダーを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/Project.vue

- `placeholder`属性をリンク入力フィールドに追加
- `placeholder`の値は"https://"に設定



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/360/files#diff-4e8aa41e439d638b3e4fb2ed6b5fc5fd543a6e78b8e5431f82746141b203122a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

