### PR TITLE
impl: auto patch merge

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,32 @@
+name: Auto Merge (Dependabot)
+
+on:
+  pull_request:
+    branches: 'main'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  AutoMerge:
+    name: Approve patch PR
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'owner/my_repo'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.2.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Enable auto-merge for Dependabot PRs
+        if: contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### **User description**
以下の 2 つを組み合わせた
やっていることは、
- patch バージョンの更新を自動で承認
- 他の CI が通ればマージできるように auto-merge を有効化

https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request
https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Dependabotによるパッチバージョン更新のPRを自動で承認するGitHub Actionsワークフローを追加しました。
- 他のCIが通過した場合に自動マージを有効化する設定を追加しました。
- `dependabot[bot]`が作成したPRに対してのみ動作するように条件を設定しました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-merge.yaml</strong><dd><code>Dependabot用の自動マージワークフローを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/auto-merge.yaml

<li>新しいGitHub Actionsワークフローを追加<br> <li> DependabotによるPRの自動承認を設定<br> <li> パッチバージョンの更新に対する自動マージを有効化<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/373/files#diff-3e652740b8893c7206123dee7cdfa9c9c1db3ef0abb914f2cf3c1fab3eb48015">+32/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information