### PR TITLE
fixed: repository name in `auto-merge.yaml`

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -12,7 +12,7 @@ jobs:
   AutoMerge:
     name: Approve patch PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'owner/my_repo'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'traPtitech/traPortfolio-Dashboard'
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
### **User description**
自動マージの設定でリポジトリ名不整合が起きていたので修正しました


___

### **PR Type**
configuration changes


___

### **Description**
- `.github/workflows/auto-merge.yaml` 内のリポジトリ名を修正しました。
- 自動マージの条件におけるリポジトリ名の不整合を解消しました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-merge.yaml</strong><dd><code>自動マージ設定のリポジトリ名を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/auto-merge.yaml

<li>リポジトリ名を 'owner/my_repo' から 'traPtitech/traPortfolio-Dashboard' に変更<br> <li> 自動マージ設定の条件を修正<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/380/files#diff-3e652740b8893c7206123dee7cdfa9c9c1db3ef0abb914f2cf3c1fab3eb48015">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information