### PR TITLE
fix: remove unnecessary dependency name flag

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -25,7 +25,7 @@ jobs:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
### **User description**
自動マージを出すときにパッケージ名での絞り込みがかかっていたが、これが必要ないため削除した


___

### **PR Type**
enhancement


___

### **Description**
- 自動マージのワークフローで、依存関係名の条件を削除しました。
- これにより、バージョン更新の種類のみを条件としてチェックするように簡素化されました。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>auto-merge.yaml</strong><dd><code>Simplify auto-merge condition in workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/auto-merge.yaml

<li>Removed dependency name condition from auto-merge step.<br> <li> Simplified the condition to only check update type.<br>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/384/files#diff-3e652740b8893c7206123dee7cdfa9c9c1db3ef0abb914f2cf3c1fab3eb48015">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information