### PR TITLE
formInput のボタンがはみ出ているのを修正

### DIFF
--- a/src/components/UI/FormInput.vue
+++ b/src/components/UI/FormInput.vue
@@ -88,6 +88,7 @@ const handleInput = (event: Event) => {
 }
 .input {
   flex-grow: 1;
+  min-width: 0;
   &::placeholder {
     color: $color-secondary;
   }


### PR DESCRIPTION
### **User description**
close #299


___

### **PR Type**
Bug fix


___

### **Description**
- `.input`クラスに`min-width: 0;`を追加し、SP（スマートフォン）環境での表示バグを修正。
- Android 9のChromeで確認されたフォーム入力ボタンのはみ出し問題を解決。



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormInput.vue</strong><dd><code>`.input`クラスのスタイル修正でSP表示のバグを解消</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/UI/FormInput.vue

- `.input`クラスに`min-width: 0;`を追加。
- レスポンシブデザインの問題を修正。



</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/403/files#diff-eec0aca5bbfec1ce522c080b476d26ef7d7907d2a0c6a21512ba2c3f55520445">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information