### PR TITLE
scss の import 周りを修正

### DIFF
--- a/src/styles/scrollbar.scss
+++ b/src/styles/scrollbar.scss
@@ -1,3 +1,5 @@
+@use "./color" as *;
+
 ::-webkit-scrollbar {
   width: 10px;
 }

--- a/src/styles/toast.scss
+++ b/src/styles/toast.scss
@@ -1,3 +1,5 @@
+@use "./color" as *;
+
 .Vue-Toastification__toast--success {
   background-color: $color-primary;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,11 +24,12 @@ export default defineConfig(() => ({
   css: {
     preprocessorOptions: {
       scss: {
+        api: 'modern-compiler',
         additionalData: `
-        @import "${srcPath}/styles/color.scss";
-        @import "${srcPath}/styles/z-index.scss";
-        @import "${srcPath}/styles/toast.scss";
-        @import "${srcPath}/styles/scrollbar.scss";
+        @use "${srcPath}/styles/color" as *;
+        @use "${srcPath}/styles/z-index" as *;
+        @use "${srcPath}/styles/toast" as *;
+        @use "${srcPath}/styles/scrollbar" as *;
         `
       }
     }


### PR DESCRIPTION
traPtitech/traPortfolio-UI#236 と同様に修正しました
↑と異なる部分としては、 Vite のコンパイル時に補完が効かない素の scss ファイルが `/src/styles` にいくつかあったのでその部分を追加したって感じです
確認よろしくお願いします