### PR TITLE
プロジェクト新規作成時に、メンバーの加入時期のデフォルト値を、プロジェクト開始時期にする

### DIFF
--- a/src/pages/ProjectNew.vue
+++ b/src/pages/ProjectNew.vue
@@ -92,10 +92,7 @@ const userWithDurations = computed<ProjectMemberType[]>(() =>
   users.map(user => ({
     ...user,
     duration: {
-      since: {
-        year: new Date().getFullYear(),
-        semester: 0
-      },
+      since: formValues.duration.since,
       until: undefined
     }
   }))

--- a/src/pages/ProjectNew.vue
+++ b/src/pages/ProjectNew.vue
@@ -92,7 +92,7 @@ const userWithDurations = computed<ProjectMemberType[]>(() =>
   users.map(user => ({
     ...user,
     duration: {
-      since: formValues.duration.since,
+      since: { ...formValues.duration.since },
       until: undefined
     }
   }))


### PR DESCRIPTION
### **User description**
#461 を修正
プロジェクト新規作成の際にメンバーを登録すると、メンバーの参加時期のデフォルトの値が、現在の年の前期になっている。これを、プロジェクトの開始時期に変更する。


___

### **PR Type**
Bug fix


___

### **Description**
- プロジェクト新規作成時のメンバー加入時期を修正

- 既存実装は現在年の前期を初期値としていた

- プロジェクト開始時期(`formValues.duration.since`)を使用


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ProjectNew.vue</strong><dd><code>メンバー加入時期の初期値変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/ProjectNew.vue

<li><code>duration.since</code>の初期値に<code>formValues.duration.since</code>を使用<br> <li> <code>new Date()</code>と<code>semester</code>のデフォルト設定を削除<br> <li> <code>until</code>は従来通り<code>undefined</code>


</details>


  </td>
  <td><a href="https://github.com/traPtitech/traPortfolio-Dashboard/pull/471/files#diff-02e0c08d10c3b4738460539a64f12e91bdfaaec3367a440492d3e31a4946e5da">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>